### PR TITLE
REV-028: adjust-shared-button-to-never-receive-props

### DIFF
--- a/src/components/home/ClaimAddress/claim-address.styles.js
+++ b/src/components/home/ClaimAddress/claim-address.styles.js
@@ -2,6 +2,7 @@ import ClaimAddressDesktop from 'assets/images/claim-address-desktop.svg';
 import ClaimAddressMobile from 'assets/images/claim-address-mobile.svg';
 import { ReactComponent as RawLocationPinStar } from 'assets/images/location-pin-star.svg';
 import { ReactComponent as RawLocationPin } from 'assets/images/location-pin.svg';
+import Button from 'components/shared/Button';
 import styled from 'styled-components';
 import colors from 'styles/colors';
 import mq from 'styles/media-query';
@@ -49,6 +50,12 @@ export const AddressInputWrapper = styled.div`
   `}
 `;
 
+export const AddressButton = styled(Button)`
+  background-color: ${colors.white};
+  height: 3.06rem;
+  padding: 0 0;
+`;
+
 export const LocationPinStar = styled(RawLocationPinStar)`
   margin-top: 3.75rem;
   ${mq.tablet`
@@ -81,6 +88,11 @@ export const JoinUs = styled.div`
     justify-content:space-evenly;
     height:4.5625rem
   `}
+`;
+
+export const JoinUsButton = styled(Button)`
+  color: ${colors.mineShaft};
+  background-color: ${colors.white};
 `;
 
 export const JoinUsText = styled.div`

--- a/src/components/home/ClaimAddress/index.jsx
+++ b/src/components/home/ClaimAddress/index.jsx
@@ -1,14 +1,14 @@
 import { ReactComponent as Arrow } from 'assets/images/arrow.svg';
 import { ReactComponent as WhiteLogo } from 'assets/images/white-logo.svg';
-import Button from 'components/shared/Button';
 import Input from 'components/shared/Input/index';
 import React from 'react';
-import colors from 'styles/colors';
 import {
+  AddressButton,
   AddressInputWrapper,
   ClaimAddressContainer,
   ClaimAddressItems,
   JoinUs,
+  JoinUsButton,
   JoinUsText,
   LocationPin,
   LocationPinStar,
@@ -32,15 +32,9 @@ function ClaimAddress() {
               size="md"
               placeholder="Enter Your Address"
               rightElement={
-                <Button
-                  ariaLabel="Search"
-                  padding="0 0"
-                  backgroundColor={colors.white}
-                  height="3.0625rem"
-                  onClick={() => {}}
-                >
+                <AddressButton ariaLabel="Search" onClick={() => {}}>
                   <Arrow />
-                </Button>
+                </AddressButton>
               }
             />
           </AddressInputWrapper>
@@ -51,14 +45,9 @@ function ClaimAddress() {
           <p>Start Your real estate journey with </p>
           <WhiteLogo />
         </JoinUsText>
-        <Button
-          ariaLabel="Join"
-          color={colors.mineShaft}
-          backgroundColor={colors.white}
-          onClick={() => {}}
-        >
+        <JoinUsButton ariaLabel="Join" onClick={() => {}}>
           Join Us
-        </Button>
+        </JoinUsButton>
       </JoinUs>
     </>
   );

--- a/src/components/home/ReverifiPlus/index.jsx
+++ b/src/components/home/ReverifiPlus/index.jsx
@@ -6,13 +6,13 @@ import { ReactComponent as HomeLogo } from 'assets/inspection.svg';
 import { ReactComponent as InsuranceLogo } from 'assets/insurance.svg';
 import React from 'react';
 import {
-  Button,
   FirstSection,
   Header,
   Item,
   ItemHeader,
   ItemIcon,
   MainContainer,
+  MoreButton,
   Paragraph,
   SecondSection,
 } from './reverifi-plus.styles';
@@ -33,7 +33,7 @@ function ReverifiPlus() {
           Search our network and find your supporting team to complete the
           process
         </Paragraph>
-        <Button type="button">See More</Button>
+        <MoreButton type="button">See More </MoreButton>
       </FirstSection>
       <SecondSection>
         <Item>

--- a/src/components/home/ReverifiPlus/index.jsx
+++ b/src/components/home/ReverifiPlus/index.jsx
@@ -12,9 +12,9 @@ import {
   ItemHeader,
   ItemIcon,
   MainContainer,
-  MoreButton,
   Paragraph,
   SecondSection,
+  SeeMoreButton,
 } from './reverifi-plus.styles';
 
 /**
@@ -33,7 +33,7 @@ function ReverifiPlus() {
           Search our network and find your supporting team to complete the
           process
         </Paragraph>
-        <MoreButton type="button">See More </MoreButton>
+        <SeeMoreButton type="button">See More </SeeMoreButton>
       </FirstSection>
       <SecondSection>
         <Item>

--- a/src/components/home/ReverifiPlus/reverifi-plus.styles.js
+++ b/src/components/home/ReverifiPlus/reverifi-plus.styles.js
@@ -1,3 +1,4 @@
+import Button from 'components/shared/Button';
 import styled from 'styled-components';
 import colors from 'styles/colors';
 import mq from 'styles/media-query';
@@ -47,20 +48,9 @@ export const Paragraph = styled.p`
   `}
 `;
 
-export const Button = styled.button`
-  background: ${colors.green};
+export const MoreButton = styled(Button)`
   border-radius: 1.25rem;
-  border: none;
-  color: ${colors.white};
-  font-family: montserrat;
   font-size: 1rem;
-  font-weight: 600;
-  height: 2.5rem;
-  width: 7.3rem;
-
-  :hover {
-    cursor: pointer;
-  }
 `;
 
 export const SecondSection = styled.div`

--- a/src/components/home/ReverifiPlus/reverifi-plus.styles.js
+++ b/src/components/home/ReverifiPlus/reverifi-plus.styles.js
@@ -48,7 +48,7 @@ export const Paragraph = styled.p`
   `}
 `;
 
-export const MoreButton = styled(Button)`
+export const SeeMoreButton = styled(Button)`
   border-radius: 1.25rem;
   font-size: 1rem;
 `;

--- a/src/components/shared/Button/Button.style.js
+++ b/src/components/shared/Button/Button.style.js
@@ -2,17 +2,17 @@ import styled from 'styled-components';
 import colors from 'styles/colors';
 
 const StyledButton = styled.button`
-  background-color: ${({ backgroundColor }) => backgroundColor || colors.green};
-  border-radius: ${({ borderRadius }) => borderRadius || '1.75rem'};
+  background-color: ${colors.green};
+  border-radius: 1.75rem;
   border: none;
-  color: ${({ color }) => color || colors.white};
+  color: ${colors.white};
   cursor: pointer;
   font-family: Montserrat;
   font-size: 0.75rem;
   font-weight: 600;
-  height: ${({ height }) => height || '2.5rem'};
+  height: 2.5rem;
   outline: none;
-  padding: ${({ padding }) => padding || '0 2rem'};
+  padding: 0 2rem;
 
   &[disabled] {
     cursor: not-allowed;

--- a/src/components/shared/Button/Button.style.js
+++ b/src/components/shared/Button/Button.style.js
@@ -7,7 +7,8 @@ const StyledButton = styled.button`
   border: none;
   color: ${({ color }) => color || colors.white};
   cursor: pointer;
-  font-size: ${({ fontSize }) => fontSize || '0.75rem'};
+  font-family: Montserrat;
+  font-size: 0.75rem;
   font-weight: 600;
   height: ${({ height }) => height || '2.5rem'};
   outline: none;

--- a/src/components/shared/Button/index.jsx
+++ b/src/components/shared/Button/index.jsx
@@ -28,25 +28,10 @@ function Button({ ariaLabel, children, disabled, onClick, type, ...props }) {
 }
 
 Button.propTypes = {
-  /**
-   * Aria label for button.
-   */
   ariaLabel: PropTypes.string,
-  /**
-   * Child nodes to render.
-   */
   children: PropTypes.node.isRequired,
-  /**
-   * Whether button disabled
-   */
   disabled: PropTypes.bool,
-  /**
-   * Event get fired when button clicked.
-   */
   onClick: PropTypes.func,
-  /**
-   * Button type (can be 'button' or 'submit').
-   */
   type: PropTypes.oneOf(['button', 'submit']),
 };
 

--- a/src/components/shared/Navbar/index.jsx
+++ b/src/components/shared/Navbar/index.jsx
@@ -1,10 +1,10 @@
 import { ReactComponent as Avatar } from 'assets/images/avatar.svg';
 import { ReactComponent as ChevronDown } from 'assets/images/chevron-down.svg';
-import { ReactComponent as JoinNow } from 'assets/images/join-now.svg';
 import { ReactComponent as SearchIcon } from 'assets/images/search-icon.svg';
 import { useUser } from 'contexts/UserContext';
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
+import Button from '../Button';
 import {
   BroadNavContainer,
   Logo,
@@ -14,9 +14,9 @@ import {
   NavItemsContainer,
   NavLinksContainer,
   NotificationBell,
+  SignInButton,
   StyledInput,
   StyledInputGroup,
-  TransparentButton,
   UserControlSectionWrapper,
   UserNavControlContainer,
   UserNavRegContainer,
@@ -64,10 +64,10 @@ function Navbar() {
           </UserNavControlContainer>
         ) : (
           <UserNavRegContainer>
-            <TransparentButton type="button" onClick={() => navigate('login')}>
+            <SignInButton type="button" onClick={() => navigate('login')}>
               Sign In
-            </TransparentButton>
-            <JoinNow onClick={() => navigate('sign-up')} />
+            </SignInButton>
+            <Button onClick={() => navigate('sign-up')}>Join Now</Button>
           </UserNavRegContainer>
         )}
       </NavItemsContainer>

--- a/src/components/shared/Navbar/navbar.styles.js
+++ b/src/components/shared/Navbar/navbar.styles.js
@@ -4,6 +4,7 @@ import { Menu } from 'react-feather';
 import styled from 'styled-components';
 import colors from 'styles/colors';
 import mq from 'styles/media-query';
+import Button from '../Button';
 
 export const BroadNavContainer = styled.div`
   align-items: center;
@@ -68,7 +69,7 @@ export const UserNavRegContainer = styled.div`
   ${mq.tablet`
     align-items: center;
     display: flex;
-    gap: 1.5rem;
+    gap: 0.5rem;
     width: 15.625rem;
   `}
 `;
@@ -119,13 +120,8 @@ export const Logo = styled(RawLogo)`
   `}
 `;
 
-export const TransparentButton = styled.button`
-  background: transparent;
-  border: none;
-  color: ${colors.white};
-  cursor: pointer;
-  font-family: Montserrat;
-  font-weight: 600;
+export const SignInButton = styled(Button)`
+  background-color: transparent;
 `;
 
 export const NotificationBell = styled(RawNotificationBell)`


### PR DESCRIPTION
### Description
Adjusted buttons which pass props for styling to the shared button component. Now we import the shared button in the styled sheet, inherit its styling inside a new styled button component, and then use it in the index.jsx file.

These changes were made on the following sections:
+ NavBar from the shared components.
+ ReverifiPlus in Home page.
+ ClaimAddress in Home page.

Links: 
[Reverifi Design](https://www.figma.com/file/22d3bKcFL0ipWIZJOUY3Km/reverifi?node-id=0%3A1)
[Reverifi Excel sheet](https://docs.google.com/spreadsheets/d/1o7cWWsGAgbzCfvuCwblf2ExczTyPkWbfx2UhRbEpRLo/edit#gid=0)