### PR TITLE
REV-244-saved-listing-overlapping-happens-when-the-seller-name-is-too-long

### DIFF
--- a/src/components/saved-agents-listings/SavedListings/index.jsx
+++ b/src/components/saved-agents-listings/SavedListings/index.jsx
@@ -149,7 +149,7 @@ function SavedListings() {
 
                   <TableCell wordBreak>{address}</TableCell>
 
-                  <TableCell>
+                  <TableCell wordBreak>
                     <AgentInfoContainer>
                       <AgentImage src={agent?.userInfo?.image || agentImage} />
                       <AgentName>


### PR DESCRIPTION
### Jira URL

https://optimumpartners.atlassian.net/browse/REV-244

### Description

- fix seller name word break in the saved listings

