### PR TITLE
Update CICD to use nvm

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,8 +17,7 @@ jobs:
           key: ${{ secrets.FRONT_END_KEY }}
           port: ${{ secrets.PORT }}
           script: |
-            export NVM_DIR=~/.nvm
-            source ~/.nvm/nvm.sh
+            export NVM_DIR=~/.nvm && source ~/.nvm/nvm.sh
             export REACT_APP_API_URL=https://reverifi.sociumtech.com
             cd /home/reverifi-frontend/reverifi && git checkout package-lock.json && git pull origin main
             cd /home/reverifi-frontend/reverifi

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -17,6 +17,8 @@ jobs:
           key: ${{ secrets.FRONT_END_KEY }}
           port: ${{ secrets.PORT }}
           script: |
+            export NVM_DIR=~/.nvm
+            source ~/.nvm/nvm.sh
             export REACT_APP_API_URL=https://reverifi.sociumtech.com
             cd /home/reverifi-frontend/reverifi && git checkout package-lock.json && git pull origin main
             cd /home/reverifi-frontend/reverifi


### PR DESCRIPTION
Use nvm instead of the current installed node / npm, so that we can use an updated version of node / npm packages that matches what needed
currently: node v 16.13.2 / npm v 8.1.2

### Jira URL

https://optimumpartners.atlassian.net/browse/JIRA_ISSUE_ID

### Description

_What problem is this branch meant to solve, what changes does it make, and how do these changes fix that problem?_

### Dependencies in Other PRs,Repo

_If this pull request relates to or depends on any changes in backend/frontend repo PR link it here._

### Testing Instructions

_How to test this and check for any possible regressions. Provide test data when applicable._
